### PR TITLE
Adding getters in html configuration

### DIFF
--- a/src/main/java/org/htmlunit/cyberneko/HTMLConfiguration.java
+++ b/src/main/java/org/htmlunit/cyberneko/HTMLConfiguration.java
@@ -485,11 +485,6 @@ public class HTMLConfiguration extends ParserConfigurationSettings implements XM
         }
     }
 
-    /** getDocumentHandler */
-    public XMLDocumentHandler getDocumentHandler_() {
-        return documentHandler_;
-    }
-
     /** getHtmlComponents_ */
     public List<HTMLComponent> getHtmlComponents_() {
         return htmlComponents_;

--- a/src/main/java/org/htmlunit/cyberneko/HTMLConfiguration.java
+++ b/src/main/java/org/htmlunit/cyberneko/HTMLConfiguration.java
@@ -484,4 +484,29 @@ public class HTMLConfiguration extends ParserConfigurationSettings implements XM
             return str.toString();
         }
     }
+
+    /** getDocumentHandler */
+    public XMLDocumentHandler getDocumentHandler_() {
+        return documentHandler_;
+    }
+
+    /** getHtmlComponents_ */
+    public List<HTMLComponent> getHtmlComponents_() {
+        return htmlComponents_;
+    }
+
+    /** getDocumentScanner_ */
+    public HTMLScanner getDocumentScanner_() {
+        return documentScanner_;
+    }
+
+    /** getTagBalancer_ */
+    public HTMLTagBalancer getTagBalancer_() {
+        return tagBalancer_;
+    }
+
+    /** getNamespaceBinder_ */
+    public NamespaceBinder getNamespaceBinder_() {
+        return namespaceBinder_;
+    }
 }

--- a/src/main/java/org/htmlunit/cyberneko/parsers/DOMFragmentParser.java
+++ b/src/main/java/org/htmlunit/cyberneko/parsers/DOMFragmentParser.java
@@ -448,6 +448,11 @@ public class DOMFragmentParser implements XMLDocumentHandler {
     public void endDocument(final Augmentations augs) throws XNIException {
     }
 
+    /** getXMLParserConfiguration */
+    public XMLParserConfiguration getXMLParserConfiguration() {
+        return this.parserConfiguration_;
+    }
+
     //
     // DEBUG
     //

--- a/src/main/java/org/htmlunit/cyberneko/parsers/DOMFragmentParser.java
+++ b/src/main/java/org/htmlunit/cyberneko/parsers/DOMFragmentParser.java
@@ -450,7 +450,7 @@ public class DOMFragmentParser implements XMLDocumentHandler {
 
     /** getXMLParserConfiguration */
     public XMLParserConfiguration getXMLParserConfiguration() {
-        return this.parserConfiguration_;
+        return parserConfiguration_;
     }
 
     //


### PR DESCRIPTION
Adding getters  for htmlComponents_, documentScanner_, tagBalancer_, namespaceBinder_ in HTMLConfiguration
and parserConfiguration_ in DOMFragmentParser

Atlassian is maintaining antisamy forked using neko-htmlunit-2.67.0 but after upgrading neko-htmlunit to 3.5.0 it's breaking our implementation due to some of the members of `HtmlConfiguration` changed to private and `xMLParserConfiguration` is also now private.
We are maintaining antisamy for Confluence-DC, for which we're parsing XHTML, and we want to preserve it as XHTML
We are using an extension to the `HTMLTagBalancer` which will preserve the self closing syntax/style for a self closing container element. e.g. a `<p/>` should remain a `<p/>`. The base class implementation would convert it to `<p></p>`.
To achieve the requirement we are to overriding `HtmlConfiguration.reset()` and accessing `htmlComponents_` to remove the neko's tagbalancer and using own tagbalancer in `AntiSamyDOMScanner` and `AntiSamySAXScanner` and also we need SAXParser's configuration and `XMLParserConfiguration`.